### PR TITLE
Don't remove the dist-packages directory when creating the dist tarball

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -341,40 +341,9 @@ if STATIC_BUILD:
 # It's not a build command with --static or it's not a build command at all
 else:
 
-    # If the dist-packages directory is non-empty
-    if os.listdir(STATIC_DIST_PACKAGES):
-        # If we are building something or running from the source
-        if DIST_BUILDING_COMMAND or (RUNNING_FROM_SOURCE and "install" in sys.argv):
-            sys.stderr.write((
-                "Installing from source or not building with --static, so clearing "
-                "out dist-packages: {}\n\nIf you wish to install a static version "
-                "from the source distribution, use setup.py install --static\n\n"
-                "ENTER to continue or CTRL+C to cancel\n\n"
-            ).format(STATIC_DIST_PACKAGES))
-            sys.stdin.readline()
-            shutil.rmtree(STATIC_DIST_PACKAGES)
-            os.mkdir(STATIC_DIST_PACKAGES)
-        else:
-            # There are distributed requirements in dist-packages, so ignore
-            # everything in the requirements.txt file
-            DIST_REQUIREMENTS = []
-            DIST_NAME = 'ka-lite-static'
-
-            if "ka-lite" in get_installed_packages():
-                raise RuntimeError(
-                    "Already installed ka-lite so cannot install ka-lite-static. "
-                    "Remove existing ka-lite-static packages, for instance using \n"
-                    "\n"
-                    "    pip uninstall ka-lite-static  # Standard\n"
-                    "    sudo apt-get remove ka-lite  # Ubuntu/Debian\n"
-                    "\n"
-                    "...or other possible installation mechanisms you may have "
-                    "been using."
-                )
-
     # No dist-packages/ and not building, so must be installing the dynamic
     # version
-    elif not DIST_BUILDING_COMMAND:
+    if not os.listdir(STATIC_DIST_PACKAGES) and not DIST_BUILDING_COMMAND:
         # Check that static version is not already installed
         if "ka-lite-static" in get_installed_packages():
                 raise RuntimeError(


### PR DESCRIPTION
In the upstream version of setup.py, this directory gets checked for
build commands such as 'sdist' right before creating the distribution
even in cases where --static is not passed as an argument, and one out
of two possible actions are taken in that directory is NOT empty:
1. If running from sources or a build command (e.g. sdist), the
   directory gets simply removed and it's bits discarded, as it's
   assumed that we're building the "dynamic" version of KA Lite,
   which uses system's libraries.
2. Otherwise, DIST_NAME changes to 'ka-lite-static' as if we were
   building with --static, even though this code gets only executed
   when 'not STATIC_BUILD', which seems a bit contradictory.

This behaviour is giving us trouble when creating the debian sources
in Jenkins from the git repository, since we are not building with
--static (as we don't want to use pip to automatically download the
libraries to be bundled, but the ones already in the repo).

However, at the same time we don't really want to delete the contents
of the dist-packages repository, since that would mean that the result
debian sources would miss the bundled python modules we have in the
git repository (which was based on the upstream debian package).

So, the best solution seems to be to simply remove that strange code
path that would remove the dist-packages directory, if it exists,
before running sdist, so that both KA Lite and its required modules
get bundled, the package properly built and the flatpak running.

https://phabricator.endlessm.com/T4489
