### PR TITLE
Fix Jenkins build: do not use an absolute path to refer to kalitectl.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -55,6 +55,12 @@ if 'bdist_wheel' in sys.argv:
 # Path of setup.py, used to resolve path of requirements.txt file
 where_am_i = os.path.dirname(os.path.realpath(__file__))
 
+# Do not use an absolute path here when running this from inside the sources directory
+# to prevent generating an absolute path in the SOURCES.txt file, that will get distutils
+# failing to process setup.py build on Jenkins (no absolute paths allowed).
+if where_am_i == os.getcwd():
+    where_am_i = './'
+
 # Handle requirements
 RAW_REQUIREMENTS = open(os.path.join(where_am_i, 'requirements.txt'), 'r').read().split("\n")
 


### PR DESCRIPTION
When building the debian sources in Jenkins `python setup build `is run
from the sources directory, meaning that we can use relative paths to
resolve the requirements instead of using absolute paths.

Doing otherwise will break the process later on since a `/src/kalitectl.py`
path will be written to the ka_lite.egg-info/SOURCES.txt file, which will
then stop the proces since distutils does not allow absolute paths in there.

It's still unclear to me why this was not a problem before and it's failing
now, so this is probably not upstreameable, but I think it's worth a try
to get Jenkins back on track, as we can always revisit this issue when
we rebase KA Lite to a newer version in the future.

https://phabricator.endlessm.com/T18155